### PR TITLE
Python 3 compatability

### DIFF
--- a/caselib.py
+++ b/caselib.py
@@ -48,12 +48,6 @@ class CaseConverter(CaseVisitor):
         raise ValueError('cannot route %r to %r' % (src, dest))
 
     def __call__(self, src, dest, text):
-        # compatibility for version 0.0.1
-        if isinstance(src, basestring):
-            from warnings import warn
-            warn('Placement text argument at the first is deprecated. Place '
-                 'at the last instead.', DeprecationWarning)
-            text, src, dest = src, dest, text
         try:
             return super(CaseConverter, self).__call__(src, dest, text)
         except KeyError:
@@ -65,12 +59,6 @@ class CaseConverter(CaseVisitor):
 class CaseSplitter(CaseVisitor):
 
     def __call__(self, case, text):
-        # compatibility for version 0.0.1
-        if isinstance(case, basestring):
-            from warnings import warn
-            warn('Placement text argument at the first is deprecated. Place '
-                 'at the last instead.', DeprecationWarning)
-            text, case = case, text
         try:
             return super(CaseSplitter, self).__call__(case, text)
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -46,25 +46,6 @@ class CaselibTestCase(unittest.TestCase):
         assert 'helloWorld' == convert(hypen_case, camelCase, 'hello-world')
         assert 'hello_world' == convert(hypen_case, snake_case, 'hello-world')
 
-    def test_compatibility(self):
-        from caselib import convert, CamelCase, camelCase, snake_case, \
-                            SNAKE_CASE, hypen_case, HYPEN_CASE
-        assert 'helloWorld'  == convert('HelloWorld', CamelCase, camelCase)
-        assert 'hello_world' == convert('HelloWorld', CamelCase, snake_case)
-        assert 'HELLO_WORLD' == convert('HelloWorld', CamelCase, SNAKE_CASE)
-        assert 'HelloWorld'  == convert('helloWorld', camelCase, CamelCase)
-        assert 'hello_world' == convert('helloWorld', camelCase, snake_case)
-        assert 'HELLO_WORLD' == convert('helloWorld', camelCase, SNAKE_CASE)
-        assert 'HelloWorld'  == convert('hello_world', snake_case, CamelCase)
-        assert 'helloWorld'  == convert('hello_world', snake_case, camelCase)
-        assert 'HELLO_WORLD' == convert('hello_world', snake_case, SNAKE_CASE)
-        assert 'HelloWorld'  == convert('HELLO_WORLD', SNAKE_CASE, CamelCase)
-        assert 'helloWorld'  == convert('HELLO_WORLD', SNAKE_CASE, camelCase)
-        assert 'hello_world' == convert('HELLO_WORLD', SNAKE_CASE, snake_case)
-        assert 'hello-world' == convert('HELLO_WORLD', SNAKE_CASE, hypen_case)
-        assert 'hello-world' == convert('helloWorld', camelCase, hypen_case)
-        assert 'HELLO-WORLD' == convert('helloWorld', camelCase, HYPEN_CASE)
-
 
 def test_suite():
     loader = unittest.TestLoader()

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def test_suite():
 
 setup(
     name='caselib',
-    version='0.1.2',
+    version='0.2.0',
     license='BSD',
     author='Heungsub Lee',
     author_email=re.sub('((sub).)(.*)', r'\2@\1.\3', 'sublee'),


### PR DESCRIPTION
All that is required to make caselib compatible with Python 3 is to remove use of basestring.

The only place basestring was used was handling support for 0.0.1 style argument order, that has been deprecated for 10 years, so I took the approach of just removing support for 0.0.1 order arguments rather than handling str vs bytes vs unicode vs basestring.

You may prefer the opposite.